### PR TITLE
feat: add blog at /blog and /blog/[slug]

### DIFF
--- a/app/(root)/(descendants)/blog/[slug]/page.tsx
+++ b/app/(root)/(descendants)/blog/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import BlogContent from "@/components/blog/content";
+import { getBlogPosts, getSingleBlogPost } from "@/lib/blog";
+import { notFound } from "next/navigation";
+
+export default async function BlogPostPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = getSingleBlogPost(slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  return <BlogContent post={post} />;
+}
+
+export function generateStaticParams() {
+  return getBlogPosts().map(({ slug }) => ({ slug }));
+}
+
+export const dynamicParams = false;

--- a/app/(root)/(descendants)/blog/page.tsx
+++ b/app/(root)/(descendants)/blog/page.tsx
@@ -1,0 +1,15 @@
+import BlogList from "@/components/blog/list";
+import { getBlogPosts } from "@/lib/blog";
+
+export default function BlogPage() {
+  const posts = getBlogPosts();
+
+  return (
+    <div className={"container mx-auto pt-16"}>
+      <h1 id={"blog"} className={"font-mono font-medium text-2xl mt-8 mb-4"}>
+        Blog
+      </h1>
+      <BlogList posts={posts} />
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 @plugin "tailwindcss-animate";
+@plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/components/blog/card.tsx
+++ b/components/blog/card.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import BlogPost from "@/types/blog";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { MagicCard } from "@/components/magicui/magic-card";
+import Link from "next/link";
+import { useTheme } from "next-themes";
+import { Badge } from "@/components/ui/badge";
+import { format } from "date-fns";
+
+export default function BlogCard({ post }: { post: BlogPost }) {
+  const { theme } = useTheme();
+
+  return (
+    <Link href={post.url} key={post.slug}>
+      <Card className={"p-0 h-full bg-accent/50 dark:bg-accent/35"}>
+        <MagicCard
+          className={"h-full"}
+          gradientColor={theme === "dark" ? "#262626" : "#D9D9D955"}
+        >
+          <div className={"grid grid-cols-[1fr_auto] gap-4"}>
+            <CardHeader className={"py-6"}>
+              <div className={"flex flex-col gap-2"}>
+                <CardTitle>{post.title}</CardTitle>
+                {post.description && (
+                  <CardDescription>{post.description}</CardDescription>
+                )}
+              </div>
+            </CardHeader>
+            <Badge
+              className={"bg-muted/50 mt-4 mr-4 rounded-full h-fit"}
+              variant={"outline"}
+            >
+              {format(post.publishedDate, "MMM d, yyyy")}
+            </Badge>
+          </div>
+          {post.tags && post.tags.length > 0 && (
+            <CardContent
+              className={
+                "pb-4 text-muted-foreground text-sm flex flex-col gap-2"
+              }
+            >
+              <div className={"flex flex-wrap gap-2"}>
+                {post.tags.map((tag) => (
+                  <Badge
+                    key={tag}
+                    variant={"outline"}
+                    className={"bg-muted/50 rounded-full h-fit"}
+                  >
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            </CardContent>
+          )}
+        </MagicCard>
+      </Card>
+    </Link>
+  );
+}

--- a/components/blog/content.tsx
+++ b/components/blog/content.tsx
@@ -1,0 +1,46 @@
+import BlogPost from "@/types/blog";
+import { MDXRemote } from "next-mdx-remote/rsc";
+import { Badge } from "@/components/ui/badge";
+import { format } from "date-fns";
+
+export default function BlogContent({ post }: { post: BlogPost }) {
+  return (
+    <article className={"container mx-auto"}>
+      <header className={"flex flex-col gap-3"}>
+        <h1 className={"font-medium text-3xl"}>{post.title}</h1>
+        {post.description && (
+          <p className={"text-muted-foreground text-lg"}>{post.description}</p>
+        )}
+        <div
+          className={
+            "flex flex-wrap items-center gap-3 text-muted-foreground text-sm"
+          }
+        >
+          <time dateTime={post.publishedDate.toISOString()}>
+            {format(post.publishedDate, "MMMM d, yyyy")}
+          </time>
+          {post.updatedDate && (
+            <span>· Updated {format(post.updatedDate, "MMMM d, yyyy")}</span>
+          )}
+          {post.tags && post.tags.length > 0 && (
+            <div className={"flex flex-wrap gap-2"}>
+              {post.tags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant={"outline"}
+                  className={"bg-muted/50 rounded-full h-fit"}
+                >
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      </header>
+
+      <div className={"mt-8 prose prose-neutral dark:prose-invert max-w-none"}>
+        <MDXRemote source={post.content} />
+      </div>
+    </article>
+  );
+}

--- a/components/blog/list.tsx
+++ b/components/blog/list.tsx
@@ -1,0 +1,18 @@
+import BlogCard from "@/components/blog/card";
+import type BlogPost from "@/types/blog";
+
+export default function BlogList({ posts }: { posts: BlogPost[] }) {
+  if (posts.length === 0) {
+    return (
+      <p className={"text-muted-foreground"}>No posts yet — check back soon.</p>
+    );
+  }
+
+  return (
+    <div className="mt-8 flex flex-col gap-4">
+      {posts.map((post) => (
+        <BlogCard key={post.slug} post={post} />
+      ))}
+    </div>
+  );
+}

--- a/components/experience/content.tsx
+++ b/components/experience/content.tsx
@@ -1,7 +1,5 @@
-"use client";
-
 import Experience from "@/types/experience";
-import { MDXProvider } from "@mdx-js/react";
+import { MDXRemote } from "next-mdx-remote/rsc";
 
 export default function ExperienceContent({
   experience,
@@ -18,9 +16,9 @@ export default function ExperienceContent({
         </div>
       </div>
 
-      <MDXProvider>
-        <div>{experience.content}</div>
-      </MDXProvider>
+      <div className={"mt-6 prose prose-neutral dark:prose-invert max-w-none"}>
+        <MDXRemote source={experience.content} />
+      </div>
     </div>
   );
 }

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -1,0 +1,63 @@
+import { getMdx, getMdxList } from "@/lib/get-mdx";
+import BlogPost from "@/types/blog";
+import path from "path";
+import { z } from "zod";
+
+const blogDirectory = path.join(process.cwd(), "/content/blog");
+
+const blogSchema = z.object({
+  title: z.string(),
+  description: z.string().optional(),
+  publishedYear: z.number(),
+  publishedMonth: z.number(),
+  publishedDay: z.number(),
+  updatedYear: z.number().optional(),
+  updatedMonth: z.number().optional(),
+  updatedDay: z.number().optional(),
+  tags: z.array(z.string()).optional(),
+  draft: z.boolean().optional(),
+});
+
+const blogMapper = (
+  data: z.infer<typeof blogSchema>,
+  content: string,
+  slug: string,
+): BlogPost => ({
+  title: data.title,
+  description: data.description,
+  slug,
+  url: `/blog/${slug}`,
+  publishedDate: new Date(
+    `${data.publishedYear}-${data.publishedMonth}-${data.publishedDay}`,
+  ),
+  updatedDate:
+    data.updatedYear && data.updatedMonth && data.updatedDay
+      ? new Date(`${data.updatedYear}-${data.updatedMonth}-${data.updatedDay}`)
+      : undefined,
+  tags: data.tags,
+  draft: data.draft ?? false,
+  content,
+});
+
+export function getBlogPosts(): BlogPost[] {
+  const posts = getMdxList<BlogPost, typeof blogSchema>(
+    blogDirectory,
+    blogSchema,
+    blogMapper,
+  );
+
+  const includeDrafts = process.env.NODE_ENV === "development";
+
+  return posts
+    .filter((post) => includeDrafts || !post.draft)
+    .sort((a, b) => b.publishedDate.getTime() - a.publishedDate.getTime());
+}
+
+export function getSingleBlogPost(slug: string): BlogPost | undefined {
+  return getMdx<BlogPost, typeof blogSchema>(
+    blogDirectory,
+    blogSchema,
+    blogMapper,
+    slug,
+  );
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lucide-react": "^0.562.0",
     "motion": "^12.23.26",
     "next": "16.1.1",
+    "next-mdx-remote": "^6.0.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
@@ -35,6 +36,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
+    "@tailwindcss/typography": "^0.5.19",
     "@types/node": "^25.0.3",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       next:
         specifier: 16.1.1
         version: 16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next-mdx-remote:
+        specifier: ^6.0.0
+        version: 6.0.0(@types/react@19.2.7)(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -78,6 +81,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.1.18
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.1.18)
       '@types/node':
         specifier: ^25.0.3
         version: 25.0.3
@@ -776,6 +782,11 @@ packages:
   '@tailwindcss/postcss@4.1.18':
     resolution: {integrity: sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -1161,6 +1172,11 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -2118,6 +2134,12 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-mdx-remote@6.0.0:
+    resolution: {integrity: sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ==}
+    engines: {node: '>=14', npm: '>=7'}
+    peerDependencies:
+      react: '>=16'
+
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -2236,6 +2258,10 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -2632,6 +2658,9 @@ packages:
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
 
+  unist-util-remove@4.0.0:
+    resolution: {integrity: sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==}
+
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
 
@@ -2640,6 +2669,9 @@ packages:
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -2657,6 +2689,12 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vfile-matter@5.0.1:
+    resolution: {integrity: sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -2694,6 +2732,11 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3339,6 +3382,11 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.18
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.1.18)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.1.18
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -3736,6 +3784,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -5032,6 +5082,20 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-mdx-remote@6.0.0(@types/react@19.2.7)(react@19.2.3):
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@mdx-js/mdx': 3.1.1
+      '@mdx-js/react': 3.1.1(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      unist-util-remove: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      vfile-matter: 5.0.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
   next-themes@0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -5161,6 +5225,11 @@ snapshots:
   picomatch@4.0.3: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss@8.4.31:
     dependencies:
@@ -5688,6 +5757,12 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  unist-util-remove@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unist-util-stringify-position@4.0.0:
     dependencies:
       '@types/unist': 3.0.3
@@ -5698,6 +5773,12 @@ snapshots:
       unist-util-is: 6.0.1
 
   unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  unist-util-visit@5.1.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
@@ -5740,6 +5821,13 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  util-deprecate@1.0.2: {}
+
+  vfile-matter@5.0.1:
+    dependencies:
+      vfile: 6.0.3
+      yaml: 2.8.4
 
   vfile-message@4.0.3:
     dependencies:
@@ -5801,6 +5889,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.4: {}
 
   yocto-queue@0.1.0: {}
 

--- a/types/blog.ts
+++ b/types/blog.ts
@@ -1,0 +1,13 @@
+type BlogPost = {
+  title: string;
+  description?: string;
+  slug: string;
+  url: string;
+  publishedDate: Date;
+  updatedDate?: Date;
+  tags?: string[];
+  draft: boolean;
+  content: string;
+};
+
+export default BlogPost;


### PR DESCRIPTION
## Summary
- Adds blog routes: `/blog` lists posts, `/blog/[slug]` renders a single post (statically generated)
- Posts populate from `content/blog/*.mdx` with zod-validated frontmatter; drafts visible only in development
- Refactors MDX rendering to use `next-mdx-remote/rsc` so `ExperienceContent` and the new `BlogContent` actually compile MDX instead of rendering it as a raw string. Adds `@tailwindcss/typography` for prose styling.

## Frontmatter schema
```yaml
---
title: "Post title"
description: "Optional summary"
publishedYear: 2026
publishedMonth: 5
publishedDay: 10
updatedYear: 2026       # optional
updatedMonth: 5         # optional
updatedDay: 11          # optional
tags: ["nextjs", "mdx"] # optional
draft: false            # optional, default false
---
```

## Test plan
- [x] `pnpm build` — `/blog` static, `/blog/[slug]` SSG, experience pages still build
- [x] `npx tsc --noEmit`
- [x] `pnpm exec prettier --check` on changed files
- [ ] Drop a sample `content/blog/hello.mdx` and confirm list + detail render with prose styling
- [ ] Verify experience pages still render MDX bodies correctly after the refactor